### PR TITLE
Allow processing of multiple remotes

### DIFF
--- a/functions/gityaw.fish
+++ b/functions/gityaw.fish
@@ -4,23 +4,26 @@ function gityaw -d "Replace Git HTTPS remote by SSH"
     return 1
   end
 
-  if not set remote (command git remote show)
-    echo "No remote available"
-    return 1
+  if test (count $argv) -gt 0
+    set remotes $argv
+  else
+    if not set remotes (command git remote show)
+      echo "No remote available"
+      return 1
+    end
   end
 
-  set https (command git remote get-url $remote)
+  for remote in $remotes
+    echo "Processing remote $remote..."
+    set https (command git remote get-url $remote)
 
-  if echo $https | grep -q '.*@.*:.*'
-    echo "Git remote looks to be already a valid SSH remote"
-    return 1
+    if echo $https | grep -q '.*@.*:.*'
+      echo "Git remote looks to be already a valid SSH remote" 
+    else
+      set regex 's/https:\/\/\(.*\)\/\(.*\)\/\(.*\)\(.git\)*/git@\1:\2\/\3.git/' 
+      echo $https | sed -e "$regex" | sed -e 's/\.git\.git$/\.git/' | read -l ssh
+      command git remote set-url "$remote" "$ssh"
+      echo "Replaced '$https' by '$ssh'"
+    end
   end
-
-  set regex 's/https:\/\/\(.*\)\/\(.*\)\/\(.*\)\(.git\)*/git@\1:\2\/\3.git/' 
-
-  echo $https | sed -e "$regex" | read -l ssh
-
-  command git remote set-url "$remote" "$ssh"
-
-  echo "Replaced '$https' by '$ssh'"
 end


### PR DESCRIPTION
If a repo has multiple remotes, `gityaw` will not process all of them by default. Remotes to process can also be specified as arguments.

Also fixed a bug that resulted in a double `.git.git` at the end of the new URL sometimes.