### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/functions/gitunyaw.fish
+++ b/functions/gitunyaw.fish
@@ -1,5 +1,5 @@
 function gitunyaw -d "Replace Git SSH remote by HTTPS"
-  if not git status >/dev/null ^&1
+  if not git status >/dev/null 2>&1
     echo "This doesn't look to be a git repository"
     return 1
   end

--- a/functions/gityaw.fish
+++ b/functions/gityaw.fish
@@ -1,5 +1,5 @@
 function gityaw -d "Replace Git HTTPS remote by SSH"
-  if not git status >/dev/null ^&1
+  if not git status >/dev/null 2>&1
     echo "This doesn't look to be a git repository"
     return 1
   end


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618